### PR TITLE
「陽性患者の属性」テーブルから退院の列を削除

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -13,9 +13,6 @@
       :mobile-breakpoint="0"
       class="cardTable"
     />
-    <div class="note">
-      {{ $t('※退院には、死亡退院を含む') }}
-    </div>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"
@@ -25,29 +22,6 @@
     </template>
   </data-view>
 </template>
-
-<i18n>
-{
-  "ja": {
-    "※退院には、死亡退院を含む": "※退院には、死亡退院を含む"
-  },
-  "en": {
-    "※退院には、死亡退院を含む": "* The number of discharge include discharge due to death"
-  },
-  "zh-cn": {
-    "※退院には、死亡退院を含む": "※ 出院数包含因死亡出院"
-  },
-  "zh-tw": {
-    "※退院には、死亡退院を含む": "※ 出院包含因死亡出院"
-  },
-  "ko": {
-    "※退院には、死亡退院を含む": "※퇴원은 사망으로 인해 퇴원한것을 포함합니다"
-  },
-  "ja-basic": {
-    "※退院には、死亡退院を含む": ""
-  }
-}
-</i18n>
 
 <style lang="scss">
 .cardTable {

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -4,8 +4,7 @@ const headers = [
   { text: '日付', value: '日付' },
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
-  { text: '性別', value: '性別' },
-  { text: '退院※', value: '退院', align: 'center' }
+  { text: '性別', value: '性別' }
 ]
 
 type DataType = {
@@ -13,7 +12,6 @@ type DataType = {
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性'
-  退院: '◯' | null
   [key: string]: any
 }
 
@@ -22,7 +20,6 @@ type TableDataType = {
   居住地: DataType['居住地']
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
-  退院: DataType['退院']
 }
 
 type TableDateType = {
@@ -40,8 +37,7 @@ export default (data: DataType[]) => {
       日付: dayjs(d['リリース日']).format('MM/DD') ?? '不明',
       居住地: d['居住地'] ?? '不明',
       年代: d['年代'] ?? '不明',
-      性別: d['性別'] ?? '不明',
-      退院: d['退院']
+      性別: d['性別'] ?? '不明'
     }
     tableDate.datasets.push(TableRow)
   })


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #40

## ⛏ 変更内容 / Details of Changes

- 「陽性患者の属性」から退院欄を削除しました。
- 上記に伴い、「※退院には、死亡退院を含む」という注意書きに関するコードも削除しました。


## 📸 スクリーンショット / Screenshots

変更前
![スクリーンショット 2020-04-08 8 44 07](https://user-images.githubusercontent.com/19761425/78729551-47be2680-7975-11ea-858c-139efe70db66.png)


変更後
![スクリーンショット 2020-04-08 8 35 44](https://user-images.githubusercontent.com/19761425/78729061-02e5c000-7974-11ea-81e3-41132bf05641.png)
