### PR TITLE
出典元リンクに対するラベルを適したものに変更

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:button>
       <span />
     </template>
@@ -19,6 +19,9 @@
         :s-text="info.sText"
         :unit="info.unit"
       />
+    </template>
+    <template v-slot:footer>
+      <open-data-link v-show="url" :url="url" :label="urlLabel" />
     </template>
   </data-view>
 </template>
@@ -72,9 +75,10 @@
 <script>
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import OpenDataLink from '@/components/OpenDataLink.vue'
 
 export default {
-  components: { DataView, DataViewBasicInfoPanel },
+  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
   props: {
     title: {
       type: String,
@@ -98,6 +102,11 @@ export default {
       default: () => {}
     },
     url: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    urlLabel: {
       type: String,
       required: false,
       default: ''

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -29,18 +29,7 @@
       </div>
       <v-footer class="DataView-Footer">
         <time :datetime="date">{{ $t('{date} 更新', { date }) }}</time>
-        <a
-          v-if="url"
-          class="OpenDataLink"
-          :href="url"
-          target="_blank"
-          rel="noopener"
-        >
-          {{ $t('オープンデータへのリンク') }}
-          <v-icon class="ExternalLinkIcon" size="15">
-            mdi-open-in-new
-          </v-icon>
-        </a>
+        <slot name="footer" />
       </v-footer>
     </div>
   </v-card>
@@ -49,28 +38,22 @@
 <i18n>
 {
   "ja": {
-    "{date} 更新": "{date} 更新",
-    "オープンデータへのリンク": "出典：【埼玉県】新型コロナウイルス感染症の発生状況"
+    "{date} 更新": "{date} 更新"
   },
   "en": {
-    "{date} 更新": "Last update: {date}",
-    "オープンデータへのリンク": "Link to Open Data"
+    "{date} 更新": "Last update: {date}"
   },
   "zh-cn": {
-    "{date} 更新": "{date} 更新",
-    "オープンデータへのリンク": "公开数据的链接"
+    "{date} 更新": "{date} 更新"
   },
   "zh-tw": {
-    "{date} 更新": "{date} 更新",
-    "オープンデータへのリンク": "開放資料連結"
+    "{date} 更新": "{date} 更新"
   },
   "ko": {
-    "{date} 更新": "{date} 갱신",
-    "オープンデータへのリンク": "공공데이터에의 링크"
+    "{date} 更新": "{date} 갱신"
   },
   "ja-basic": {
-    "{date} 更新": "{date} に あたらしく しました",
-    "オープンデータへのリンク": "オープンデータ という ページを みたいとき"
+    "{date} 更新": "{date} に あたらしく しました"
   }
 }
 </i18n>
@@ -84,7 +67,6 @@ export default class DataView extends Vue {
   @Prop() private title!: string
   @Prop() private titleId!: string
   @Prop() private date!: string
-  @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
 
   formattedDate: string = convertDatetimeToISO8601Format(this.date)
@@ -168,12 +150,6 @@ export default class DataView extends Vue {
     color: $gray-3 !important;
     text-align: right;
     background-color: $white !important;
-    .OpenDataLink {
-      text-decoration: none;
-      .ExternalLinkIcon {
-        vertical-align: text-bottom;
-      }
-    }
   }
 }
 </style>

--- a/components/OpenDataLink.vue
+++ b/components/OpenDataLink.vue
@@ -1,0 +1,47 @@
+<template>
+  <a class="OpenDataLink" :href="url" target="_blank" rel="noopener">
+    {{ $t(label) }}
+    <v-icon class="ExternalLinkIcon" size="15">
+      mdi-open-in-new
+    </v-icon>
+  </a>
+</template>
+
+<i18n>
+{
+  "ja": {
+    "オープンデータへのリンク": "出典：【埼玉県】新型コロナウイルス感染症の発生状況"
+  },
+  "en": {
+    "オープンデータへのリンク": "Link to Open Data"
+  },
+  "zh-cn": {
+    "オープンデータへのリンク": "公开数据的链接"
+  },
+  "zh-tw": {
+    "オープンデータへのリンク": "開放資料連結"
+  },
+  "ko": {
+    "オープンデータへのリンク": "공공데이터에의 링크"
+  },
+  "ja-basic": {
+    "オープンデータへのリンク": "オープンデータ という ページを みたいとき"
+  }
+}
+</i18n>
+<style lang="scss">
+.OpenDataLink {
+  text-decoration: none;
+  .ExternalLinkIcon {
+    vertical-align: text-bottom;
+  }
+}
+</style>
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+@Component
+export default class OpenDataLink extends Vue {
+  @Prop() private label!: string
+  @Prop() private url!: string
+}
+</script>

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,11 +1,5 @@
 <template>
-  <data-view
-    class="SvgCard"
-    :title="title"
-    :title-id="titleId"
-    :date="date"
-    :url="url"
-  >
+  <data-view class="SvgCard" :title="title" :title-id="titleId" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{
@@ -15,6 +9,9 @@
         }}<br />
         {{ $t('（県内市公表分やチャーター便帰国者を含む）') }}
       </p>
+    </template>
+    <template v-slot:footer>
+      <open-data-link v-show="url" :url="url" :label="urlLabel" />
     </template>
     <slot />
   </data-view>
@@ -65,9 +62,10 @@
 
 <script>
 import DataView from '@/components/DataView.vue'
+import OpenDataLink from '@/components/OpenDataLink.vue'
 
 export default {
-  components: { DataView },
+  components: { DataView, OpenDataLink },
   props: {
     title: {
       type: String,
@@ -82,6 +80,10 @@ export default {
       default: ''
     },
     url: {
+      type: String,
+      default: ''
+    },
+    urlLabel: {
       type: String,
       default: ''
     }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:description>
       <slot name="description" />
     </template>
@@ -18,6 +18,9 @@
         :s-text="displayInfo.sText"
         :unit="displayInfo.unit"
       />
+    </template>
+    <template v-slot:footer>
+      <open-data-link v-show="url" :url="url" :label="urlLabel" />
     </template>
   </data-view>
 </template>
@@ -68,9 +71,10 @@
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import OpenDataLink from '@/components/OpenDataLink.vue'
 
 export default {
-  components: { DataView, DataSelector, DataViewBasicInfoPanel },
+  components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
   props: {
     title: {
       type: String,
@@ -103,6 +107,11 @@ export default {
       default: ''
     },
     url: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    urlLabel: {
       type: String,
       required: false,
       default: ''

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -5,6 +5,7 @@
       :title-id="'details-of-confirmed-cases'"
       :date="Data.inspections_summary.date"
       :url="'https://www.pref.saitama.lg.jp/a0701/covid19/jokyo.html'"
+      :url-label="$t('出典：新型コロナウイルス感染症の県内の発生状況')"
     >
       <confirmed-cases-table
         :aria-label="$t('検査陽性者の状況')"

--- a/components/cards/InspectionSummaryCard.vue
+++ b/components/cards/InspectionSummaryCard.vue
@@ -8,6 +8,11 @@
       :date="Data.inspections_summary.date"
       :unit="$t('件')"
       :url="'https://opendata.pref.saitama.lg.jp/data/dataset/covid19-kensa'"
+      :url-label="
+        $t(
+          '出典：【埼玉県】埼玉県が実施した新型コロナウイルス疑い例検査数（延べ人数）'
+        )
+      "
     >
       <template v-slot:description>
         <ul>

--- a/components/cards/confirmed-cases-attributes-card.vue
+++ b/components/cards/confirmed-cases-attributes-card.vue
@@ -8,6 +8,7 @@
       :date="Data.patients.date"
       :info="sumInfoOfPatients"
       :url="'https://opendata.pref.saitama.lg.jp/data/dataset/covid19-jokyo'"
+      :url-label="$t('オープンデータへのリンク')"
     />
   </v-col>
 </template>

--- a/components/cards/confirmed-cases-number-card.vue
+++ b/components/cards/confirmed-cases-number-card.vue
@@ -8,6 +8,7 @@
       :date="Data.patients.date"
       :unit="$t('人')"
       :url="'https://opendata.pref.saitama.lg.jp/data/dataset/covid19-jokyo'"
+      :url-label="$t('オープンデータへのリンク')"
       :option-count="optionCount"
     />
   </v-col>


### PR DESCRIPTION
- add OpenDataLink from original tokyo code
  and enable to receive url label
- set appropriate url label for each link

## 📝 関連issue / Related Issues

- close #56 

## ⛏ 変更内容 / Details of Changes

- 東京のコードを参考に OpenDataLink を追加
  - ただそのままではラベルを変更できないので、label としてカスタムできるように変更
- 各 card から URL と共にラベルを渡すように対応
- https://www.pref.saitama.lg.jp/a0701/covid19/jokyo.html へのラベルも適切ではなかったので合わせて変更

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/952100/79047252-6f9cdb00-7c50-11ea-975a-9b0f900cce68.png)
