### PR TITLE
検査陽性者の状況 更新日時参照先変更

### DIFF
--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -3,7 +3,7 @@
     <svg-card
       :title="$t('検査陽性者の状況')"
       :title-id="'details-of-confirmed-cases'"
-      :date="Data.inspections_summary.date"
+      :date="Data.patients.date"
       :url="'https://www.pref.saitama.lg.jp/a0701/covid19/jokyo.html'"
       :url-label="$t('出典：新型コロナウイルス感染症の県内の発生状況')"
     >


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #61 

## ⛏ 変更内容 / Details of Changes
- 検査陽性者の状況（ConfirmedCasesDetailsCard.vue）の更新日時を Data.inspections_summary.date から Data.patients.date に変更。
