### PR TITLE
issue#59 CONTRIBUTING.mdに記載されているSlackワークスペースの情報を埼玉版に変更

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 * good first issue / help wanted / bug を優先して対応いただけると助かります
 
 ## コミュニケーションへの参加方法
-* Code for Japan の Slack アカウントを持っていない場合、[こちらから登録](https://codefortoda-slackin.herokuapp.com/)してください
+* Code for TODA の Slack アカウントを持っていない場合、[こちらから登録](https://codefortoda-slackin.herokuapp.com/)してください
 * `#stopcovid19jp` チャンネルにご参加ください。
 
 ## 参加にあたって

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,8 +14,8 @@
 * good first issue / help wanted / bug を優先して対応いただけると助かります
 
 ## コミュニケーションへの参加方法
-* Code for Japan の Slack アカウントを持っていない場合、[こちらから登録](https://cfjslackin.herokuapp.com/)してください
-* `#covid19` チャンネルにご参加ください。
+* Code for Japan の Slack アカウントを持っていない場合、[こちらから登録](https://codefortoda-slackin.herokuapp.com/)してください
+* `#stopcovid19jp` チャンネルにご参加ください。
 
 ## 参加にあたって
 * 開発に参加する前に、[Principle/行動規範](CODE_OF_CONDUCT.md) をご一読ください。

--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -14,7 +14,7 @@ This page shows how you can contribute to the development of this site.
 * We appreciate if you give priority to the issues labelled [good first issue / help wanted / bug]
 
 ## How to participate in communications
-* If you do not have a "Code for Japan" Slack account, please register [here](https://codefortoda-slackin.herokuapp.com/)
+* If you do not have a "Code for TODA" Slack account, please register [here](https://codefortoda-slackin.herokuapp.com/)
 * Join `#stopcovid19jp` Channel
 
 ## For participation

--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -14,8 +14,8 @@ This page shows how you can contribute to the development of this site.
 * We appreciate if you give priority to the issues labelled [good first issue / help wanted / bug]
 
 ## How to participate in communications
-* If you do not have a "Code for Japan" Slack account, please register [here](https://cfjslackin.herokuapp.com/)
-* Join `#covid19` Channel
+* If you do not have a "Code for Japan" Slack account, please register [here](https://codefortoda-slackin.herokuapp.com/)
+* Join `#stopcovid19jp` Channel
 
 ## For participation
 * Please read [Principle / Code of Conduct](CODE_OF_CONDUCT_EN.md) before participating in development.


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #59 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
- CONTRIBUTING.mdに記載されているSlackワークスペースURLを以下の変更
```
https://cfjslackin.herokuapp.com/
↓
https://codefortoda-slackin.herokuapp.com/
```
- CONTRIBUTING.mdに記載されているSlackチャンネル名を以下に変更
```
#covid19
↓
#stopcovid19jp
```
- 英語版も同様に対応 

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
- 日本語版
<img src="https://gyazo.com/f9819109f4184164b454c43cc7d6e01d/raw" width="700" />

- 英語版
<img src="https://gyazo.com/aa09809987c994229c564f8803742fb6/raw" width="700" />