### PR TITLE
fix #77 やさしいにほんごの見出しと実績値が重ならないように修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -60,6 +60,7 @@ export default class DataView extends Vue {
     position: absolute;
     top: 25px;
     right: 25px;
+    width: 40%;
     &-summary {
       color: $gray-2;
       font-family: Hiragino Sans;
@@ -73,6 +74,7 @@ export default class DataView extends Vue {
       }
     }
     &-date {
+      white-space: normal;
       font-size: 12px;
       line-height: 12px;
       color: $gray-3;
@@ -94,7 +96,7 @@ export default class DataView extends Vue {
     flex-flow: column;
     color: $gray-2;
     &.with-infoPanel {
-      width: calc(100% - 11em);
+      width: 50%;
     }
   }
   &-Title {

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -24,7 +24,7 @@
       }
     }
     &-date {
-      white-space: nowrap;
+      white-space: normal;
       display: inline-block;
       font-size: 12px;
       line-height: 12px;


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #77 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- CSSの修正
- DataView.vueとDataViewBasicInfoPanel.vueの`.DataView-DataInfo`を`width: 40%`に`.DataView-TitleContainer.with-infoPanel`を`width: 50%`に、`.DataView-DataInfo-date`を`white-space: normal`にし、重ならないようにした
  - 40%なのは50%ではEdgeブラウザで少し重なっているように見えたためのもの



## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

これはFirefoxでのスクリーンショットです。
![Screenshot_2020-06-06 埼玉県 新型コロナウイルス感染症対策サイト(2)](https://user-images.githubusercontent.com/305368/83935090-1b961900-a7f1-11ea-8467-c52d2970e69b.png)


![Screenshot_2020-06-06 埼玉県 新型コロナウイルス感染症対策サイト(3)](https://user-images.githubusercontent.com/305368/83935087-0faa5700-a7f1-11ea-99b2-8d69faa56938.png)

