### PR TITLE
#80 陽性患者数などのバーチャートで0人を表示させる

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -122,12 +122,30 @@ export default {
       }
     },
     displayData() {
+      const zeroMouseOverHeight = 5
+      const transparentWhite = '#FFFFFF00'
+
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
             return d.label
           }),
           datasets: [
+            {
+              label: this.dataKind,
+              data: this.chartData.map(_d => {
+                return 0
+              }),
+              backgroundColor: transparentWhite,
+              borderColor: transparentWhite,
+              borderWidth: 0,
+              minBarLength: this.chartData.map(d => {
+                if (d.transition <= 0) {
+                  return zeroMouseOverHeight
+                }
+                return 0
+              })
+            },
             {
               label: this.dataKind,
               data: this.chartData.map(d => {
@@ -144,6 +162,21 @@ export default {
           return d.label
         }),
         datasets: [
+          {
+            label: this.dataKind,
+            data: this.chartData.map(_d => {
+              return 0
+            }),
+            backgroundColor: transparentWhite,
+            borderColor: transparentWhite,
+            borderWidth: 0,
+            minBarLength: this.chartData.map(d => {
+              if (d.cumulative <= 0) {
+                return zeroMouseOverHeight
+              }
+              return 0
+            })
+          },
           {
             label: this.dataKind,
             data: this.chartData.map(d => {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #80 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- バーチャートで0人のときに0人を表示します。
  - TimeBarChart.vueに、0人のときに白色かつ最低5pxのバーを追加してマウスオーバーするようにしました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![saitama-covid-19-mouseon](https://user-images.githubusercontent.com/305368/85276485-da725a00-b4bc-11ea-9895-8ee649e62c51.png)
