### PR TITLE
#83 Edgeでバーチャートを閲覧すると黒く表示される問題を修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -144,7 +144,7 @@ export default {
     },
     displayData() {
       const zeroMouseOverHeight = 5
-      const transparentWhite = '#FFFFFF00'
+      const transparentWhite = 'rgba(255, 255, 255, 0)'
 
       if (this.dataKind === 'transition') {
         return {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #{83}

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- Microsoft Edgeで0人のときに表示されるバーチャートを、透明になるようにプロパティを修正しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
Microsoft Edge
![covid-19-site-0-is-0000-on-edgehtml-after](https://user-images.githubusercontent.com/305368/85920607-256ee180-b8b0-11ea-88ac-559709a8cc91.png)

Firefox (Windows)
![Screenshot_2020-06-27 埼玉県 新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/305368/85920645-65ce5f80-b8b0-11ea-9f5c-804a46b32b56.png)

Chrome (Windows)
![covid-19-site-0-is-0000-on-chrome-after](https://user-images.githubusercontent.com/305368/85920665-8dbdc300-b8b0-11ea-923e-e4918ca79786.png)
