### PR TITLE
fix #91: 言語セレクタの位置を変更(モバイル対応)

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -17,14 +17,6 @@
         </h1>
       </nuxt-link>
     </div>
-    <v-divider class="SideNavigation-HeadingDivider" />
-    <div class="SideNavigation-Language">
-      <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
-        {{ $t('多言語対応選択メニュー') }}
-        <LanguageSelector />
-      </label>
-    </div>
-    <v-divider class="SideNavigation-HeadingDivider" />
     <div class="sp-none" :class="{ open: isNaviOpen }">
       <v-icon
         class="SideNavigation-ListContainerIcon pc-none"
@@ -34,6 +26,13 @@
         mdi-close
       </v-icon>
       <v-list :flat="true">
+        <div class="SideNavigation-Language">
+          <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
+            {{ $t('多言語対応選択メニュー') }}
+            <LanguageSelector />
+          </label>
+        </div>
+        <v-divider class="SideNavigation-Divider" />
         <v-container
           v-for="(item, i) in items"
           :key="i"


### PR DESCRIPTION
## 📝 関連issue / Related Issues


- close #91 

## ⛏ 変更内容 / Details of Changes
- モバイル環境向けに、言語セレクタがサイドナビゲーションのドロワ内に表示されるように、場所を移動した

## 📸 スクリーンショット / Screenshots

- モバイル

![image](https://user-images.githubusercontent.com/4400857/90081176-9fb3d200-dd47-11ea-920e-458a18def450.png)

![image](https://user-images.githubusercontent.com/4400857/90081187-a6424980-dd47-11ea-9eec-08baf27c4dda.png)


- PC
![image](https://user-images.githubusercontent.com/4400857/90081161-90348900-dd47-11ea-9b95-2324edcdcdf3.png)




