### PR TITLE
#95 他県版リンク先変更

### DIFF
--- a/pages/otherpref.vue
+++ b/pages/otherpref.vue
@@ -242,17 +242,23 @@ export default Vue.extend({
               link: 'https://covid19-fukui.com/'
             },
             {
-              title: this.$t('静岡市'),
-              subtitle: this.$t('公式'),
-              isOfficial: true,
-              link: 'https://stopcovid19.city.shizuoka.lg.jp/'
+              title: this.$t('静岡県'),
+              subtitle: this.$t(''),
+              isOfficial: false,
+              link: 'https://stopcovid19.code4numazu.org/'
             },
-            {
-              title: this.$t('浜松市'),
-              subtitle: this.$t('公式'),
-              isOfficial: true,
-              link: 'https://stopcovid19.code4hamamatsu.org/'
-            },
+            // {
+            //   title: this.$t('静岡市'),
+            //   subtitle: this.$t('公式'),
+            //   isOfficial: true,
+            //   link: 'https://stopcovid19.city.shizuoka.lg.jp/'
+            // },
+            // {
+            //   title: this.$t('浜松市'),
+            //   subtitle: this.$t('公式'),
+            //   isOfficial: true,
+            //   link: 'https://stopcovid19.code4hamamatsu.org/'
+            // },
             {
               title: this.$t('三重県'),
               subtitle: this.$t(''),
@@ -331,11 +337,18 @@ export default Vue.extend({
               isOfficial: false,
               link: 'https://covid19-tokushima.netlify.com/'
             },
+            // {
+            //   title: this.$t('高知県'),
+            //   subtitle: this.$t(''),
+            //   isOfficial: false,
+            //   link: 'https://covid19-kochi.netlify.app/'
+            // },
             {
               title: this.$t('高知県'),
-              subtitle: this.$t(''),
-              isOfficial: false,
-              link: 'https://covid19-kochi.netlify.app/'
+              subtitle: this.$t('公式'),
+              isOfficial: true,
+              link:
+                'https://www.pref.kochi.lg.jp/soshiki/111301/info-COVID-19.html'
             },
             {
               title: this.$t('福岡県'),


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #95 

## ⛏ 変更内容 / Details of Changes
- 高知県情報サイトがリンク切れのため、高知県公式情報へリンク先変更
- 静岡県へのリンクがなかったため（静岡市・浜松市となっていた）新規追加し、市別へのリンクを削除
